### PR TITLE
feat!: Support translations caching in plugins

### DIFF
--- a/VSTranslations.sln
+++ b/VSTranslations.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSTranslations.Plugin.Abstractions.UnitTests", "tests\VSTranslations.Plugin.Abstractions.UnitTests\VSTranslations.Plugin.Abstractions.UnitTests.csproj", "{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -146,6 +148,18 @@ Global
 		{2341322E-67D3-4555-88DD-5433FB783222}.Release|arm64.Build.0 = Release|Any CPU
 		{2341322E-67D3-4555-88DD-5433FB783222}.Release|x86.ActiveCfg = Release|x86
 		{2341322E-67D3-4555-88DD-5433FB783222}.Release|x86.Build.0 = Release|x86
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|arm64.Build.0 = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Debug|x86.Build.0 = Debug|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|arm64.ActiveCfg = Release|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|arm64.Build.0 = Release|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -160,6 +174,7 @@ Global
 		{A8AA55E1-37AA-4558-9978-A43ABEA9E1EF} = {FFA244F0-D7B0-4130-A27D-B77539D450DD}
 		{D5083806-3FD9-459C-857B-A1FAFD425D14} = {9B7066A9-DCEC-48D1-AC45-A49D6E8EAA3D}
 		{2341322E-67D3-4555-88DD-5433FB783222} = {3F4EF46B-61CD-45F2-89D7-F118A7F7C2C7}
+		{BCC9C110-9C0A-4F70-BCF4-2888C2EA91AB} = {9B7066A9-DCEC-48D1-AC45-A49D6E8EAA3D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13DE4F0D-2522-4000-B21C-5D1CFA1A3E07}

--- a/src/VSTranslations.Plugin.Abstractions/Caching/ICache.cs
+++ b/src/VSTranslations.Plugin.Abstractions/Caching/ICache.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace VSTranslations.Plugin.Abstractions.Caching;
+
+/// <summary>
+/// An interface describing cache service.
+/// </summary>
+public interface ICache
+{
+    /// <summary>
+    /// Asynchronously gets or creates a cache entry
+    /// for the provided value.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="key">Cache entry key.</param>
+    /// <param name="valueFactory">Value factory.</param>
+    /// <returns><see cref="Task{TResult}"/> indicating the completion with <typeparamref name="TValue"/> as a result.</returns>
+    Task<TValue> GetOrCreateAsync<TKey, TValue>(TKey key, Func<Task<TValue>> valueFactory);
+}

--- a/src/VSTranslations.Plugin.Abstractions/Caching/ICacheFactory.cs
+++ b/src/VSTranslations.Plugin.Abstractions/Caching/ICacheFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace VSTranslations.Plugin.Abstractions.Caching;
+
+/// <summary>
+/// An interface describing <see cref="ICache"/> factory.
+/// </summary>
+public interface ICacheFactory
+{
+    /// <summary>
+    /// Creates <see cref="ICache"/> instance.
+    /// </summary>
+    /// <returns><see cref="ICache"/> instance.</returns>
+    ICache Create();
+}

--- a/src/VSTranslations.Plugin.Abstractions/Extensions/CacheExtensions.cs
+++ b/src/VSTranslations.Plugin.Abstractions/Extensions/CacheExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using System;
+using VSTranslations.Plugin.Abstractions.Translating;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.Plugin.Abstractions.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="ICache"/>.
+/// </summary>
+internal static class CacheExtensions
+{
+    /// <summary>
+    /// Gets or sets translated string for the specific pair
+    /// of languages.
+    /// </summary>
+    /// <param name="cache"><see cref="ICache"/> instance.</param>
+    /// <param name="source">Source language.</param>
+    /// <param name="sourceText">Source text.</param>
+    /// <param name="target">Target language.</param>
+    /// <param name="targetTextFactory">Target text factory.</param>
+    /// <returns><see cref="Task{TResult}"/> indicating the completion with translated string as a result.</returns>
+    public static Task<string> GetOrSetTranslationAsync(this ICache cache, Language source, string sourceText,
+        Language target, Func<Task<string>> targetTextFactory)
+    {
+        var entryKey = $"{source.Code}{target.Code}+{sourceText}";
+
+        return cache.GetOrCreateAsync(entryKey, targetTextFactory);
+    }
+}

--- a/src/VSTranslations.Plugin.Abstractions/VSTranslations.Plugin.Abstractions.csproj
+++ b/src/VSTranslations.Plugin.Abstractions/VSTranslations.Plugin.Abstractions.csproj
@@ -4,7 +4,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>

--- a/src/VSTranslations.Plugin.GoogleTranslate/GoogleTranslatorEngine.cs
+++ b/src/VSTranslations.Plugin.GoogleTranslate/GoogleTranslatorEngine.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using VSTranslations.Plugin.Abstractions.Translating;
 using System.Net;
-using Microsoft.VisualStudio.OLE.Interop;
+using VSTranslations.Plugin.Abstractions.Caching;
 
 namespace VSTranslations.Plugin.GoogleTranslate
 {
@@ -23,13 +23,13 @@ namespace VSTranslations.Plugin.GoogleTranslate
         private readonly HttpClient _httpClient;
 
         [ImportingConstructor]
-        public GoogleTranslatorEngine(ITranslatorEngineConfig<GoogleTranslatorEngine> translatorEngineConfig)
-            : this(new HttpClientHandler(), translatorEngineConfig)
+        public GoogleTranslatorEngine(ITranslatorEngineConfig<GoogleTranslatorEngine> translatorEngineConfig, ICacheFactory cacheFactory)
+            : this(new HttpClientHandler(), translatorEngineConfig, cacheFactory)
         {
         }
 
-        internal GoogleTranslatorEngine(HttpMessageHandler handler, ITranslatorEngineConfig<GoogleTranslatorEngine> translatorEngineConfig)
-            : base(translatorEngineConfig)
+        internal GoogleTranslatorEngine(HttpMessageHandler handler, ITranslatorEngineConfig<GoogleTranslatorEngine> translatorEngineConfig, ICacheFactory cacheFactory)
+            : base(translatorEngineConfig, cacheFactory)
         {
             _httpClient = new HttpClient(handler);
         }

--- a/src/VSTranslations/Extensions/MemoryCacheExtensions.cs
+++ b/src/VSTranslations/Extensions/MemoryCacheExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.Threading;
+using System.Threading.Tasks;
+using VSTranslations.Plugin.Abstractions.Translating;
+
+namespace VSTranslations.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="IMemoryCache"/>.
+/// </summary>
+internal static class MemoryCacheExtensions
+{
+    /// <summary>
+    /// Gets or creates a lazy-asynchronous cache entry
+    /// for the provided value.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="memoryCache"><see cref="IMemoryCache"/> instance.</param>
+    /// <param name="key">Cache entry key.</param>
+    /// <param name="valueFactory">Value factory.</param>
+    /// <returns><see cref="Task{TResult}"/> indicating the completion with <typeparamref name="TValue"/> as a result.</returns>
+    public static Task<TValue> GetOrCreateLazyAsync<TKey, TValue>(this IMemoryCache memoryCache, TKey key, Func<Task<TValue>> valueFactory)
+    {
+        var asyncLazyInstance = memoryCache.GetOrCreate(key, _ =>
+            new AsyncLazy<TValue>(valueFactory, ThreadHelper.JoinableTaskFactory));
+
+        return asyncLazyInstance.GetValueAsync();
+    }
+}

--- a/src/VSTranslations/Services/Caching/ConfiguredCacheBase.cs
+++ b/src/VSTranslations/Services/Caching/ConfiguredCacheBase.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using VSTranslations.Options;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.Services.Caching;
+
+/// <summary>
+/// A base class implementing <see cref="ICache"/> that
+/// provides controlled caching via <see cref="GeneralOptions"/>.
+/// </summary>
+internal abstract class ConfiguredCacheBase : ICache
+{
+    /// <inheritdoc/>
+    public async Task<TValue> GetOrCreateAsync<TKey, TValue>(TKey key, Func<Task<TValue>> valueFactory)
+    {
+        var options = await GeneralOptions.GetLiveInstanceAsync();
+        if (options is null || !options.EnableCaching)
+        {
+            return await valueFactory.Invoke();
+        }
+
+        return await GetOrCreateValueAsync(key, valueFactory);
+    }
+
+    protected abstract Task<TValue> GetOrCreateValueAsync<TKey, TValue>(TKey key, Func<Task<TValue>> valueFactory);
+}

--- a/src/VSTranslations/Services/Caching/DefaultMemoryCache.cs
+++ b/src/VSTranslations/Services/Caching/DefaultMemoryCache.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using System.Threading.Tasks;
+using VSTranslations.Extensions;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.Services.Caching;
+
+/// <summary>
+/// An in-memory cache implementation of <see cref="ICache"/>
+/// that uses <see cref="MemoryCache"/> underneath.
+/// </summary>
+internal class DefaultMemoryCache : ConfiguredCacheBase
+{
+    private readonly IMemoryCache _cache;
+
+    public DefaultMemoryCache() : this(CreateInternalMemoryCache())
+    {
+    }
+
+    internal DefaultMemoryCache(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
+
+    protected override Task<TValue> GetOrCreateValueAsync<TKey, TValue>(TKey key, Func<Task<TValue>> valueFactory) =>
+        _cache.GetOrCreateLazyAsync(key, valueFactory);
+
+    private static IMemoryCache CreateInternalMemoryCache()
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions());
+        return new MemoryCache(options);
+    }
+}

--- a/src/VSTranslations/Services/Caching/DefaultMemoryCacheFactory.cs
+++ b/src/VSTranslations/Services/Caching/DefaultMemoryCacheFactory.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using System.ComponentModel.Composition;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.Services.Caching;
+
+/// <summary>
+/// Default implementation of <see cref="ICacheFactory"/>.
+/// </summary>
+[Export(typeof(ICacheFactory))]
+internal class DefaultMemoryCacheFactory : ICacheFactory
+{
+    /// <summary>
+    /// Creates <see cref="DefaultMemoryCache"/> instance if cache is enabled.
+    /// </summary>
+    /// <returns><see cref="DefaultMemoryCache"/> as <see cref="IMemoryCache"/>.</returns>
+    public ICache Create() => new DefaultMemoryCache();
+}

--- a/src/VSTranslations/VSTranslations.csproj
+++ b/src/VSTranslations/VSTranslations.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Delegates\SpanTranslateDelegate.cs" />
     <Compile Include="Extensions\EditorSettingsExtensions.cs" />
     <Compile Include="Extensions\FontSizeConverterExtensions.cs" />
+    <Compile Include="Extensions\MemoryCacheExtensions.cs" />
     <Compile Include="Extensions\SnapshotSpanExtensions.cs" />
     <Compile Include="Extensions\TagAggregatorExtensions.cs" />
     <Compile Include="Extensions\TextViewExtensions.cs" />
@@ -97,6 +98,9 @@
     <Compile Include="Services\Adornments\TranslatedTextAdornmentTagger.cs" />
     <Compile Include="Services\Adornments\TranslatedTextAdornmentTaggerProvider.cs" />
     <Compile Include="Services\Adornments\InMemoryAdornmentCache.cs" />
+    <Compile Include="Services\Caching\ConfiguredCacheBase.cs" />
+    <Compile Include="Services\Caching\DefaultMemoryCache.cs" />
+    <Compile Include="Services\Caching\DefaultMemoryCacheFactory.cs" />
     <Compile Include="Services\Settings\EditorSettings.cs" />
     <Compile Include="Services\Settings\EditorSettingsFactory.cs" />
     <Compile Include="Services\Tagging\TranslatedLineGlyphFactoryProvider.cs" />
@@ -161,6 +165,9 @@
     <PackageReference Include="Community.VisualStudio.VSCT" Version="16.0.29.6" PrivateAssets="all" />
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.492" ExcludeAssets="Runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory">
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Imaging">
       <Version>17.4.33103.184</Version>

--- a/tests/VSTranslations.Plugin.Abstractions.UnitTests/Extensions/CacheExtensionsTests.cs
+++ b/tests/VSTranslations.Plugin.Abstractions.UnitTests/Extensions/CacheExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿using AutoFixture.Xunit2;
+using Moq;
+using VSTranslations.Plugin.Abstractions.Caching;
+using VSTranslations.Plugin.Abstractions.Translating;
+using VSTranslations.Plugin.Abstractions.Extensions;
+using VSTranslations.UnitTests.AutoFixture.Attributes;
+using Xunit;
+using FluentAssertions;
+
+namespace VSTranslations.Plugin.Abstractions.UnitTests.Extensions;
+
+public class CacheExtensionsTests
+{
+    [Theory]
+    [DefaultAutoData]
+    public async Task GetOrSetTranslationAsync_WhenSourceAndTargetProvided_ShouldCacheTranslation(
+    [Frozen] Mock<ICache> cache, Language source, Language target, string sourceText, string targetText)
+    {
+        // Arrange
+        var key = $"{source.Code}{target.Code}+{sourceText}";
+        var targetValueFactory = () => Task.FromResult(targetText);
+
+        cache
+            .Setup(self => self.GetOrCreateAsync(key, targetValueFactory))
+            .Returns((string _, Func<Task<string>> factory) => factory());
+
+        // Act
+        var cachedValue = await cache.Object.GetOrSetTranslationAsync(source, sourceText, target, targetValueFactory);
+
+        // Assert
+        cachedValue.Should().Be(targetText);
+    }
+}

--- a/tests/VSTranslations.Plugin.Abstractions.UnitTests/VSTranslations.Plugin.Abstractions.UnitTests.csproj
+++ b/tests/VSTranslations.Plugin.Abstractions.UnitTests/VSTranslations.Plugin.Abstractions.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VSTranslations.Plugin.Abstractions\VSTranslations.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\VsTranslations.UnitTests.Common\VSTranslations.UnitTests.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/VSTranslations.Plugin.GoogleTranslate.UnitTests/AutoFixture/Attributes/GoogleTranslatorEngineAutoDataAttribute.cs
+++ b/tests/VSTranslations.Plugin.GoogleTranslate.UnitTests/AutoFixture/Attributes/GoogleTranslatorEngineAutoDataAttribute.cs
@@ -1,11 +1,14 @@
 ﻿using VSTranslations.Plugin.GoogleTranslate.UnitTests.AutoFixture.Customizations;
 using VSTranslations.UnitTests.AutoFixture.Attributes;
+using VSTranslations.UnitTests.Common.AutoFixture.Customizations;
 
 namespace VSTranslations.Plugin.GoogleTranslate.UnitTests.AutoFixture.Attributes;
 
 public class GoogleTranslatorEngineAutoDataAttribute : AutoDataAttributeBase
 {
     public GoogleTranslatorEngineAutoDataAttribute() : base(
+        new CacheCustomization(),
+        new CacheFactoryCustomization(),
         new HttpMessageHandlerCustomization(),
         new TranslatorEngineConfigCustomization(),
         new GoogleTranslatorEngineCustomization())

--- a/tests/VSTranslations.Plugin.GoogleTranslate.UnitTests/AutoFixture/Customizations/GoogleTranslatorEngineCustomization.cs
+++ b/tests/VSTranslations.Plugin.GoogleTranslate.UnitTests/AutoFixture/Customizations/GoogleTranslatorEngineCustomization.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using Moq;
+using VSTranslations.Plugin.Abstractions.Caching;
 using VSTranslations.Plugin.Abstractions.Translating;
 using VSTranslations.UnitTests.Common;
 
@@ -16,7 +17,7 @@ internal class GoogleTranslatorEngineCustomization : ICustomization
             .Setup(self => self(It.IsAny<HttpRequestMessage>()))
             .ReturnsAsync(() => fixture.Create<HttpResponseMessage>());
 
-        fixture.Register((HttpMessageHandler messageHandler, ITranslatorEngineConfig<GoogleTranslatorEngine> engineConfig) =>
-            new GoogleTranslatorEngine(messageHandler, engineConfig));
+        fixture.Register((HttpMessageHandler messageHandler, ITranslatorEngineConfig<GoogleTranslatorEngine> engineConfig, ICacheFactory cacheFactory) =>
+            new GoogleTranslatorEngine(messageHandler, engineConfig, cacheFactory));
     }
 }

--- a/tests/VsTranslations.UnitTests.Common/AutoFixture/Customizations/CacheCustomization.cs
+++ b/tests/VsTranslations.UnitTests.Common/AutoFixture/Customizations/CacheCustomization.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture;
+using Moq;
+using System.Threading.Tasks;
+using System;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.UnitTests.Common.AutoFixture.Customizations;
+
+public class CacheCustomization : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        var cache = fixture.Freeze<Mock<ICache>>();
+        cache
+            .Setup(self => self.GetOrCreateAsync(It.IsNotNull<string>(), It.IsNotNull<Func<Task<string>>>()))
+            .Returns((string _, Func<Task<string>> factory) => factory());
+    }
+}

--- a/tests/VsTranslations.UnitTests.Common/AutoFixture/Customizations/CacheFactoryCustomization.cs
+++ b/tests/VsTranslations.UnitTests.Common/AutoFixture/Customizations/CacheFactoryCustomization.cs
@@ -1,0 +1,17 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using Moq;
+using VSTranslations.Plugin.Abstractions.Caching;
+
+namespace VSTranslations.UnitTests.Common.AutoFixture.Customizations;
+
+public class CacheFactoryCustomization : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        var cacheFactory = fixture.Freeze<Mock<ICacheFactory>>();
+        cacheFactory
+            .Setup(self => self.Create())
+            .ReturnsUsingFixture(fixture);
+    }
+}

--- a/tests/VsTranslations.UnitTests.Common/VsTranslations.UnitTests.Common.csproj
+++ b/tests/VsTranslations.UnitTests.Common/VsTranslations.UnitTests.Common.csproj
@@ -7,17 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="AutoFixture\Customizations\**" />
-    <EmbeddedResource Remove="AutoFixture\Customizations\**" />
-    <None Remove="AutoFixture\Customizations\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VSTranslations.Plugin.Abstractions\VSTranslations.Plugin.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/VsTranslations.UnitTests/AutoFixture/Attributes/DefaultMemoryCacheAutoDataAttribute.cs
+++ b/tests/VsTranslations.UnitTests/AutoFixture/Attributes/DefaultMemoryCacheAutoDataAttribute.cs
@@ -1,0 +1,12 @@
+﻿using VSTranslations.UnitTests.AutoFixture.Customizations;
+
+namespace VSTranslations.UnitTests.AutoFixture.Attributes;
+
+public class DefaultMemoryCacheAutoDataAttribute : AutoDataAttributeBase
+{
+    public DefaultMemoryCacheAutoDataAttribute() : base(
+        new VsSettingsManagerCustomization(),
+        new DefaultMemoryCacheCustomization())
+    {
+    }
+}

--- a/tests/VsTranslations.UnitTests/AutoFixture/Customizations/DefaultMemoryCacheCustomization.cs
+++ b/tests/VsTranslations.UnitTests/AutoFixture/Customizations/DefaultMemoryCacheCustomization.cs
@@ -1,0 +1,15 @@
+﻿using AutoFixture;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using VSTranslations.Services.Caching;
+
+namespace VSTranslations.UnitTests.AutoFixture.Customizations;
+
+internal class DefaultMemoryCacheCustomization : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        fixture.Freeze<Mock<IMemoryCache>>();
+        fixture.Register((IMemoryCache cache) => new DefaultMemoryCache(cache));
+    }
+}

--- a/tests/VsTranslations.UnitTests/Extensions/MemoryCacheExtensionsTests.cs
+++ b/tests/VsTranslations.UnitTests/Extensions/MemoryCacheExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿using AutoFixture.Xunit2;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using System.Threading.Tasks;
+using VSTranslations.Extensions;
+using VSTranslations.UnitTests.AutoFixture.Attributes;
+using VSTranslations.UnitTests.Xunit;
+using Xunit;
+
+namespace VSTranslations.UnitTests.Extensions;
+
+public class MemoryCacheExtensionsTests : VsTestBase
+{
+    public MemoryCacheExtensionsTests(GlobalServiceProvider serviceProvider) : base(serviceProvider)
+    {
+    }
+
+    [Theory]
+    [DefaultAutoData]
+    public async Task GetOrCreateLazyAsync_WhenKeyAndValueFactoryProvided_ShouldInvokeReturnCachedLazyValue(
+        [Frozen] Mock<IMemoryCache> memoryCache, string key, string value)
+    {
+        // Arrange
+        var valueFactory = () => Task.FromResult(value);
+        object lazyValue = new AsyncLazy<string>(valueFactory, ThreadHelper.JoinableTaskFactory);
+        memoryCache.Setup(self => self.TryGetValue(key, out lazyValue)).Returns(true);
+
+        // Act
+        var cachedValue = await memoryCache.Object.GetOrCreateLazyAsync(key, valueFactory);
+
+        // Assert
+        cachedValue.Should().Be(value);
+    }
+}

--- a/tests/VsTranslations.UnitTests/Services/Caching/DefaultMemoryCacheFactoryTests.cs
+++ b/tests/VsTranslations.UnitTests/Services/Caching/DefaultMemoryCacheFactoryTests.cs
@@ -1,0 +1,21 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using VSTranslations.Services.Caching;
+using VSTranslations.UnitTests.AutoFixture.Attributes;
+using Xunit;
+
+namespace VSTranslations.UnitTests.Services.Caching;
+
+public class DefaultMemoryCacheFactoryTests
+{
+    [Theory]
+    [DefaultAutoData]
+    public void Create_WhenInvoked_ShouldReturnDefaultMemoryCacheInstance(IFixture fixture)
+    {
+        // Arrange
+        var memoryCacheFactory = fixture.Create<DefaultMemoryCacheFactory>();
+
+        // Act & Assert
+        memoryCacheFactory.Create().Should().BeOfType<DefaultMemoryCache>();
+    }
+}

--- a/tests/VsTranslations.UnitTests/Services/Caching/DefaultMemoryCacheTests.cs
+++ b/tests/VsTranslations.UnitTests/Services/Caching/DefaultMemoryCacheTests.cs
@@ -1,0 +1,71 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using System.Threading.Tasks;
+using VSTranslations.Options;
+using VSTranslations.Services.Caching;
+using VSTranslations.UnitTests.AutoFixture.Attributes;
+using VSTranslations.UnitTests.Xunit;
+using Xunit;
+
+namespace VSTranslations.UnitTests.Services.Caching;
+
+public class DefaultMemoryCacheTests : VsTestBase
+{
+    public DefaultMemoryCacheTests(GlobalServiceProvider serviceProvider) : base(serviceProvider)
+    {
+    }
+
+    [Theory]
+    [DefaultMemoryCacheAutoData]
+    public async Task GetOrCreateAsync_WhenCacheEnabled_ShouldReturnCachedLazyValue(
+        IFixture fixture, IVsSettingsManager settingsManager, Mock<IMemoryCache> internalCache, string key, string value)
+    {
+        // Arrange
+        ServiceProvider.AddService(typeof(SVsSettingsManager), settingsManager);
+        var options = await GeneralOptions.GetLiveInstanceAsync();
+        options.EnableCaching = true;
+
+        var valueFactory = () => Task.FromResult(value);
+        object lazyValue = new AsyncLazy<string>(valueFactory, ThreadHelper.JoinableTaskFactory);
+        internalCache.Setup(self => self.TryGetValue(key, out lazyValue)).Returns(true);
+
+        var memoryCache = fixture.Create<DefaultMemoryCache>();
+
+        // Act
+        var cachedValue = await memoryCache.GetOrCreateAsync(key, valueFactory);
+
+        // Assert
+        cachedValue.Should().Be(value);
+        internalCache.Verify(self => self.TryGetValue(key, out lazyValue), Times.Once);
+    }
+
+    [Theory]
+    [DefaultMemoryCacheAutoData]
+    public async Task GetOrCreateAsync_WhenCacheDisabled_ShouldReturnDirectValue(
+        IFixture fixture, IVsSettingsManager settingsManager, Mock<IMemoryCache> internalCache, string key, string value)
+    {
+        // Arrange
+        ServiceProvider.AddService(typeof(SVsSettingsManager), settingsManager);
+        var options = await GeneralOptions.GetLiveInstanceAsync();
+        options.EnableCaching = false;
+
+        var valueFactory = () => Task.FromResult(value);
+        object lazyValue = new AsyncLazy<string>(valueFactory, ThreadHelper.JoinableTaskFactory);
+        internalCache.Setup(self => self.TryGetValue(key, out lazyValue)).Returns(true);
+
+        var memoryCache = fixture.Create<DefaultMemoryCache>();
+
+        // Act
+        var cachedValue = await memoryCache.GetOrCreateAsync(key, valueFactory);
+
+        // Assert
+        cachedValue.Should().Be(value);
+        internalCache.Verify(self => self.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny), Times.Never);
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: ICache and ICacheFactory support for plugins. Translator engines are now required to accept ICacheFactory service.